### PR TITLE
Add missing internal modules to the bundle

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,8 @@ import typescript from '@rollup/plugin-typescript';
 
 export default /** @type {import('rollup').RollupOptions} */ ({
   input: 'src/index.ts',
-  external: () => true,
+  // internals are ./source-map-resolve or .../src/source-map-resolve.ts
+  external: name => !(name.startsWith('.') || name.endsWith('.ts')),
   plugins: [typescript()],
   output: [
     {


### PR DESCRIPTION
Insert all internal modules to `dist/index.js`.

Attempts fo fix #57.