### PR TITLE
Support watching for source changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import pluginUtils from '@rollup/pluginutils';
 import fs from 'fs';
+import { resolve as resolvePath } from 'path';
 import { ExistingRawSourceMap, Plugin, PluginContext } from 'rollup';
 import { promisify } from 'util';
 import { resolveSourceMap, resolveSources } from './source-map-resolve';
@@ -26,6 +27,9 @@ export default function sourcemaps(
       if (!filter(id)) {
         return null;
       }
+
+      // Allow the original file to be watched
+      this.addWatchFile(resolvePath(id));
 
       try {
         // Try to read the file with the given id


### PR DESCRIPTION
Plugins have to call `addWatchFile` now.

Attempts to fix #59.