### PR TITLE
fix: Having something that looks like a source mapping in your source file causes the plugin to not work.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 coverage
 .vscode
 .code
+.idea
 .DS_Store
 tsconfig.tsbuildinfo
 .rollup.cache

--- a/src/source-map-resolve.ts
+++ b/src/source-map-resolve.ts
@@ -27,10 +27,10 @@ function parseMapToJSON(string: string): ExistingRawSourceMap {
 }
 
 const sourceMappingURLRegex =
-  /(?:\/\*(?:\s*\r?\n(?:\/\/)?)?(?:[#@] sourceMappingURL=([^\s'"]*))\s*\*\/|\/\/(?:[#@] sourceMappingURL=([^\s'"]*)))\s*/;
+  /(?:\/\*(?:\s*\r?\n(?:\/\/)?)?(?:[#@] sourceMappingURL=([^\s'"]*))\s*\*\/|\/\/(?:[#@] sourceMappingURL=([^\s'"]*)))\s*/g;
 
 function getSourceMappingUrl(code: string): string | null {
-  const match = sourceMappingURLRegex.exec(code);
+  const match = Array.from(code.matchAll(sourceMappingURLRegex)).pop();
   return match ? match[1] || match[2] || '' : null;
 }
 


### PR DESCRIPTION
I was compiling an Angular project down into a singular js file because web components and noticed the source files were no longer working.

I found that the problem was that the bundelend Angular code includes something that looks like a source mapping url 

https://github.com/angular/angular/blob/5a2cc6c3907547657463be1eebbf860278e5fdc6/packages/platform-browser/src/dom/dom_renderer.ts#L46

 This plugin however only looks for the first occurrence and according to the [spec](https://sourcemaps.info/spec.html):

> The generated code may include a line at the end of the source, with the following form: 

So changing the logic to find the last source mapping should do the trick.

Maybe in the future all matches should be checked until a working one is found. Starting with last one.


This however does slow down the code a little bit, but I couldn't find a way in JS to easily search from the end of a string.