### PR TITLE
fix: correctly encode non ascii characters

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,45 +1,43 @@
-import fs from "node:fs"
-import path from "node:path"
-import util from "node:util"
-import { rollup } from "rollup"
-import ts from "typescript"
+import fs from 'node:fs';
+import path from 'node:path';
+import util from 'node:util';
+import { rollup } from 'rollup';
+import ts from 'typescript';
 /* eslint-disable @typescript-eslint/require-await, @typescript-eslint/no-non-null-assertion */
-import { describe, expect, it, test } from "vitest"
+import { describe, expect, it, test } from 'vitest';
 
-import sourcemaps, { type SourcemapsPluginOptions } from ".."
-import { resolveSourceMap } from "../source-map-resolve"
+import sourcemaps, { type SourcemapsPluginOptions } from '..';
+import { resolveSourceMap } from '../source-map-resolve';
 
-const inputPath = path.join(__dirname, "../index.ts")
-const inputText = fs.readFileSync(inputPath, "utf8")
+const inputPath = path.join(__dirname, '../index.ts');
+const inputText = fs.readFileSync(inputPath, 'utf8');
 
 const outputPath = path.format({
   dir: path.dirname(inputPath),
   name: path.basename(inputPath, path.extname(inputPath)),
-  ext: ".js",
-})
+  ext: '.js',
+});
 
 const sourceMapPath = path.format({
   dir: path.dirname(inputPath),
   name: path.basename(inputPath, path.extname(inputPath)),
-  ext: ".js.map",
-})
+  ext: '.js.map',
+});
 
 // Function to compare two file paths
 function comparePath(a: string, b: string): boolean {
   // Split the paths into segments
-  const first = a.split(/[\\/]/)
-  const second = b.split(/[\\/]/)
+  const first = a.split(/[\\/]/);
+  const second = b.split(/[\\/]/);
 
   // If the platform is Windows, convert the first segment (drive letter) to lowercase
-  if (process.platform === "win32") {
-    first[0] = first[0].toLowerCase()
-    second[0] = second[0].toLowerCase()
+  if (process.platform === 'win32') {
+    first[0] = first[0].toLowerCase();
+    second[0] = second[0].toLowerCase();
   }
 
   // Return true if both paths have the same number of segments and all corresponding segments are equal
-  return (
-    first.length === second.length && first.every((v, i) => v === second[i])
-  )
+  return first.length === second.length && first.every((v, i) => v === second[i]);
 }
 
 async function rollupBundle({
@@ -47,49 +45,49 @@ async function rollupBundle({
   sourceMapText,
   pluginOptions,
 }: ts.TranspileOutput & {
-  pluginOptions?: SourcemapsPluginOptions
+  pluginOptions?: SourcemapsPluginOptions;
 }) {
   const load = async (path: string) => {
     if (comparePath(path, inputPath)) {
-      return inputText
+      return inputText;
     }
 
     if (comparePath(path, outputPath)) {
-      return outputText
+      return outputText;
     }
 
     if (sourceMapText && comparePath(path, sourceMapPath)) {
-      return sourceMapText
+      return sourceMapText;
     }
 
-    throw new Error(`Unexpected path: ${path}`)
-  }
+    throw new Error(`Unexpected path: ${path}`);
+  };
 
   const { generate } = await rollup({
     input: outputPath,
     external: () => true,
     plugins: [
-      { name: "skip-checks", resolveId: (path) => path },
+      { name: 'skip-checks', resolveId: path => path },
       sourcemaps({
         readFile: util.callbackify(load),
         ...pluginOptions,
       }),
-      { name: "fake-fs", load },
+      { name: 'fake-fs', load },
     ],
-  })
+  });
 
   const { output } = await generate({
-    format: "esm",
+    format: 'esm',
     sourcemap: true,
     sourcemapPathTransform(relativePath) {
-      return path.resolve(__dirname, "..", "..", relativePath)
+      return path.resolve(__dirname, '..', '..', relativePath);
     },
-  })
+  });
 
-  return output[0]
+  return output[0];
 }
 
-it("ignores files with no source maps", async () => {
+it('ignores files with no source maps', async () => {
   const { outputText, sourceMapText } = ts.transpileModule(inputText, {
     fileName: inputPath,
     compilerOptions: {
@@ -97,18 +95,18 @@ it("ignores files with no source maps", async () => {
       sourceMap: false,
       inlineSourceMap: false,
     },
-  })
+  });
 
-  expect(sourceMapText).toBeUndefined()
+  expect(sourceMapText).toBeUndefined();
 
-  const { map } = await rollupBundle({ outputText, sourceMapText })
+  const { map } = await rollupBundle({ outputText, sourceMapText });
 
-  expect(map).toBeDefined()
-  expect(map?.sources).toStrictEqual([outputPath])
-  expect(map?.sourcesContent).toStrictEqual([outputText])
-})
+  expect(map).toBeDefined();
+  expect(map?.sources).toStrictEqual([outputPath]);
+  expect(map?.sourcesContent).toStrictEqual([outputText]);
+});
 
-describe("detects files with source maps", () => {
+describe('detects files with source maps', () => {
   test.each`
     sourceMap | inlineSourceMap | inlineSources
     ${true}   | ${false}        | ${false}
@@ -116,12 +114,8 @@ describe("detects files with source maps", () => {
     ${true}   | ${false}        | ${true}
     ${false}  | ${true}         | ${true}
   `(
-    "sourceMap: $sourceMap, inlineSourceMap: $inlineSourceMap, inlineSources: $inlineSources",
-    async ({
-      sourceMap,
-      inlineSourceMap,
-      inlineSources,
-    }: Record<string, boolean>) => {
+    'sourceMap: $sourceMap, inlineSourceMap: $inlineSourceMap, inlineSources: $inlineSources',
+    async ({ sourceMap, inlineSourceMap, inlineSources }: Record<string, boolean>) => {
       const { outputText, sourceMapText } = ts.transpileModule(inputText, {
         fileName: inputPath,
         compilerOptions: {
@@ -130,119 +124,109 @@ describe("detects files with source maps", () => {
           inlineSourceMap,
           inlineSources,
         },
-      })
+      });
 
       if (sourceMap) {
-        expect(sourceMapText).toBeDefined()
+        expect(sourceMapText).toBeDefined();
       } else {
-        expect(sourceMapText).toBeUndefined()
+        expect(sourceMapText).toBeUndefined();
       }
 
-      const { map } = await rollupBundle({ outputText, sourceMapText })
+      const { map } = await rollupBundle({ outputText, sourceMapText });
 
-      expect(map).toBeDefined()
-      expect(
-        map?.sources.map((source) => path.normalize(source))
-      ).toStrictEqual([inputPath])
-      expect(map?.sourcesContent).toStrictEqual([inputText])
-    }
-  )
-})
+      expect(map).toBeDefined();
+      expect(map?.sources.map(source => path.normalize(source))).toStrictEqual([inputPath]);
+      expect(map?.sourcesContent).toStrictEqual([inputText]);
+    },
+  );
+});
 
-describe("ignores filtered files", () => {
-  test("included", async () => {
+describe('ignores filtered files', () => {
+  test('included', async () => {
     const { outputText, sourceMapText } = ts.transpileModule(inputText, {
       fileName: inputPath,
       compilerOptions: {
         target: ts.ScriptTarget.ES2017,
         sourceMap: true,
       },
-    })
+    });
 
-    expect(sourceMapText).toBeDefined()
+    expect(sourceMapText).toBeDefined();
 
     const { map } = await rollupBundle({
       outputText,
       sourceMapText,
       pluginOptions: {
-        include: ["dummy-file"],
+        include: ['dummy-file'],
       },
-    })
+    });
 
-    expect(map).toBeDefined()
-    expect(map?.sources.map((source) => path.normalize(source))).toStrictEqual([
-      outputPath,
-    ])
-    expect(map?.sourcesContent).toStrictEqual([outputText])
-  })
+    expect(map).toBeDefined();
+    expect(map?.sources.map(source => path.normalize(source))).toStrictEqual([outputPath]);
+    expect(map?.sourcesContent).toStrictEqual([outputText]);
+  });
 
-  test("excluded", async () => {
+  test('excluded', async () => {
     const { outputText, sourceMapText } = ts.transpileModule(inputText, {
       fileName: inputPath,
       compilerOptions: {
         target: ts.ScriptTarget.ES2017,
         sourceMap: true,
       },
-    })
+    });
 
-    expect(sourceMapText).toBeDefined()
+    expect(sourceMapText).toBeDefined();
 
     const { map } = await rollupBundle({
       outputText,
       sourceMapText,
       pluginOptions: {
-        exclude: [
-          path.relative(process.cwd(), outputPath).split("\\").join("/"),
-        ],
+        exclude: [path.relative(process.cwd(), outputPath).split('\\').join('/')],
       },
-    })
+    });
 
-    expect(map).toBeDefined()
-    expect(map?.sources.map((source) => path.normalize(source))).toStrictEqual([
-      outputPath,
-    ])
-    expect(map?.sourcesContent).toStrictEqual([outputText])
-  })
-})
+    expect(map).toBeDefined();
+    expect(map?.sources.map(source => path.normalize(source))).toStrictEqual([outputPath]);
+    expect(map?.sourcesContent).toStrictEqual([outputText]);
+  });
+});
 
-it("delegates failing file reads to the next plugin", async () => {
+it('delegates failing file reads to the next plugin', async () => {
   const { outputText, sourceMapText } = ts.transpileModule(inputText, {
     fileName: inputPath,
     compilerOptions: {
       target: ts.ScriptTarget.ES2017,
       sourceMap: true,
     },
-  })
+  });
 
-  expect(sourceMapText).toBeDefined()
+  expect(sourceMapText).toBeDefined();
 
   const { map } = await rollupBundle({
     outputText,
     sourceMapText,
     pluginOptions: {
       readFile(_path: string, cb: (error: Error | null, data: string) => void) {
-        cb(new Error("Failed!"), "")
+        cb(new Error('Failed!'), '');
       },
     },
-  })
+  });
 
-  expect(map).toBeDefined()
-  expect(map?.sources.map((source) => path.normalize(source))).toStrictEqual([
-    outputPath,
-  ])
-  expect(map?.sourcesContent).toStrictEqual([outputText])
-})
+  expect(map).toBeDefined();
+  expect(map?.sources.map(source => path.normalize(source))).toStrictEqual([outputPath]);
+  expect(map?.sourcesContent).toStrictEqual([outputText]);
+});
 
-it("handles failing source maps reads", async () => {
+it('handles failing source maps reads', async () => {
   const { outputText, sourceMapText } = ts.transpileModule(inputText, {
     fileName: inputPath,
     compilerOptions: {
       target: ts.ScriptTarget.ES2017,
       sourceMap: true,
     },
-  })
+  });
 
-  expect(sourceMapText).toBeDefined()
+  expect(sourceMapText).toBeDefined();
 
   const { map } = await rollupBundle({
     outputText,
@@ -251,54 +235,52 @@ it("handles failing source maps reads", async () => {
       readFile: util.callbackify(async (path: string) => {
         switch (path) {
           case inputPath:
-            return inputText
+            return inputText;
           case outputPath:
-            return outputText
+            return outputText;
           default:
-            throw new Error(`Unexpected path: ${path}`)
+            throw new Error(`Unexpected path: ${path}`);
         }
       }),
     },
-  })
+  });
 
-  expect(map).toBeDefined()
-  expect(map?.sources.map((source) => path.normalize(source))).toStrictEqual([
-    outputPath,
-  ])
-  expect(map?.sourcesContent).toStrictEqual([outputText])
-})
+  expect(map).toBeDefined();
+  expect(map?.sources.map(source => path.normalize(source))).toStrictEqual([outputPath]);
+  expect(map?.sourcesContent).toStrictEqual([outputText]);
+});
 
-it("finds last source map file definition", async () => {
+it('finds last source map file definition', async () => {
   const multipleSourceMappingFile = `
     function test(sourceMapUrl: string): string {
       return \`/*# sourceMappingURL=\${sourceMapUrl} */\`;
     }
     //# sourceMappingURL=index.js.map
-  `
+  `;
 
   const multipleSourceMappingMapFile =
-    '{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAAA,SAAS,IAAI,CAAC,YAAoB;IAChC,OAAO,+BAAwB,YAAY,QAAK,CAAC;AACnD,CAAC"}'
+    '{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAAA,SAAS,IAAI,CAAC,YAAoB;IAChC,OAAO,+BAAwB,YAAY,QAAK,CAAC;AACnD,CAAC"}';
 
-  let requestedSourceMap: string | null = null
+  let requestedSourceMap: string | null = null;
 
   const map = await resolveSourceMap(
     multipleSourceMappingFile,
-    "/dev/null/index.js",
-    async (path) => {
-      requestedSourceMap = path
-      return multipleSourceMappingMapFile
-    }
-  )
+    '/dev/null/index.js',
+    async path => {
+      requestedSourceMap = path;
+      return multipleSourceMappingMapFile;
+    },
+  );
 
-  expect(requestedSourceMap).toEqual("/dev/null/index.js.map")
+  expect(requestedSourceMap).toEqual('/dev/null/index.js.map');
 
-  expect(map).toBeDefined()
-  expect(map?.url).toEqual("/dev/null/index.js.map")
-})
+  expect(map).toBeDefined();
+  expect(map?.url).toEqual('/dev/null/index.js.map');
+});
 
-it("correctly handles Chinese and non-ASCII characters in source files", async () => {
+it('correctly handles Chinese and non-ASCII characters in source files', async () => {
   // Chinese string
-  const chineseText = 'console.log("你好，世界！"); // 中文字符测试'
+  const chineseText = 'console.log("你好，世界！"); // 中文字符测试';
   // Transpile with source map
   const { outputText, sourceMapText } = ts.transpileModule(chineseText, {
     fileName: inputPath,
@@ -308,14 +290,14 @@ it("correctly handles Chinese and non-ASCII characters in source files", async (
       inlineSourceMap: false,
       inlineSources: true,
     },
-  })
+  });
 
-  expect(sourceMapText).toBeDefined()
+  expect(sourceMapText).toBeDefined();
 
-  const { map, code } = await rollupBundle({ outputText, sourceMapText })
+  const { map, code } = await rollupBundle({ outputText, sourceMapText });
 
   // The code should contain the original Chinese characters
-  expect(code).toContain("你好，世界")
+  expect(code).toContain('你好，世界');
   // The sourcesContent should also contain the original Chinese characters
-  expect(map?.sourcesContent?.[0]).toContain("你好，世界")
-})
+  expect(map?.sourcesContent?.[0]).toContain('你好，世界');
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,43 +1,45 @@
-import fs from 'node:fs';
-import path from 'node:path';
-import util from 'node:util';
-import { rollup } from 'rollup';
-import ts from 'typescript';
+import fs from "node:fs"
+import path from "node:path"
+import util from "node:util"
+import { rollup } from "rollup"
+import ts from "typescript"
 /* eslint-disable @typescript-eslint/require-await, @typescript-eslint/no-non-null-assertion */
-import { describe, expect, it, test } from 'vitest';
+import { describe, expect, it, test } from "vitest"
 
-import sourcemaps, { type SourcemapsPluginOptions } from '..';
-import { resolveSourceMap } from '../source-map-resolve';
+import sourcemaps, { type SourcemapsPluginOptions } from ".."
+import { resolveSourceMap } from "../source-map-resolve"
 
-const inputPath = path.join(__dirname, '../index.ts');
-const inputText = fs.readFileSync(inputPath, 'utf8');
+const inputPath = path.join(__dirname, "../index.ts")
+const inputText = fs.readFileSync(inputPath, "utf8")
 
 const outputPath = path.format({
   dir: path.dirname(inputPath),
   name: path.basename(inputPath, path.extname(inputPath)),
-  ext: '.js',
-});
+  ext: ".js",
+})
 
 const sourceMapPath = path.format({
   dir: path.dirname(inputPath),
   name: path.basename(inputPath, path.extname(inputPath)),
-  ext: '.js.map',
-});
+  ext: ".js.map",
+})
 
 // Function to compare two file paths
 function comparePath(a: string, b: string): boolean {
   // Split the paths into segments
-  const first = a.split(/[\\/]/);
-  const second = b.split(/[\\/]/);
+  const first = a.split(/[\\/]/)
+  const second = b.split(/[\\/]/)
 
   // If the platform is Windows, convert the first segment (drive letter) to lowercase
-  if (process.platform === 'win32') {
-    first[0] = first[0].toLowerCase();
-    second[0] = second[0].toLowerCase();
+  if (process.platform === "win32") {
+    first[0] = first[0].toLowerCase()
+    second[0] = second[0].toLowerCase()
   }
 
   // Return true if both paths have the same number of segments and all corresponding segments are equal
-  return first.length === second.length && first.every((v, i) => v === second[i]);
+  return (
+    first.length === second.length && first.every((v, i) => v === second[i])
+  )
 }
 
 async function rollupBundle({
@@ -45,49 +47,49 @@ async function rollupBundle({
   sourceMapText,
   pluginOptions,
 }: ts.TranspileOutput & {
-  pluginOptions?: SourcemapsPluginOptions;
+  pluginOptions?: SourcemapsPluginOptions
 }) {
   const load = async (path: string) => {
     if (comparePath(path, inputPath)) {
-      return inputText;
+      return inputText
     }
 
     if (comparePath(path, outputPath)) {
-      return outputText;
+      return outputText
     }
 
     if (sourceMapText && comparePath(path, sourceMapPath)) {
-      return sourceMapText;
+      return sourceMapText
     }
 
-    throw new Error(`Unexpected path: ${path}`);
-  };
+    throw new Error(`Unexpected path: ${path}`)
+  }
 
   const { generate } = await rollup({
     input: outputPath,
     external: () => true,
     plugins: [
-      { name: 'skip-checks', resolveId: path => path },
+      { name: "skip-checks", resolveId: (path) => path },
       sourcemaps({
         readFile: util.callbackify(load),
         ...pluginOptions,
       }),
-      { name: 'fake-fs', load },
+      { name: "fake-fs", load },
     ],
-  });
+  })
 
   const { output } = await generate({
-    format: 'esm',
+    format: "esm",
     sourcemap: true,
     sourcemapPathTransform(relativePath) {
-      return path.resolve(__dirname, '..', '..', relativePath);
+      return path.resolve(__dirname, "..", "..", relativePath)
     },
-  });
+  })
 
-  return output[0];
+  return output[0]
 }
 
-it('ignores files with no source maps', async () => {
+it("ignores files with no source maps", async () => {
   const { outputText, sourceMapText } = ts.transpileModule(inputText, {
     fileName: inputPath,
     compilerOptions: {
@@ -95,18 +97,18 @@ it('ignores files with no source maps', async () => {
       sourceMap: false,
       inlineSourceMap: false,
     },
-  });
+  })
 
-  expect(sourceMapText).toBeUndefined();
+  expect(sourceMapText).toBeUndefined()
 
-  const { map } = await rollupBundle({ outputText, sourceMapText });
+  const { map } = await rollupBundle({ outputText, sourceMapText })
 
-  expect(map).toBeDefined();
-  expect(map?.sources).toStrictEqual([outputPath]);
-  expect(map?.sourcesContent).toStrictEqual([outputText]);
-});
+  expect(map).toBeDefined()
+  expect(map?.sources).toStrictEqual([outputPath])
+  expect(map?.sourcesContent).toStrictEqual([outputText])
+})
 
-describe('detects files with source maps', () => {
+describe("detects files with source maps", () => {
   test.each`
     sourceMap | inlineSourceMap | inlineSources
     ${true}   | ${false}        | ${false}
@@ -114,8 +116,12 @@ describe('detects files with source maps', () => {
     ${true}   | ${false}        | ${true}
     ${false}  | ${true}         | ${true}
   `(
-    'sourceMap: $sourceMap, inlineSourceMap: $inlineSourceMap, inlineSources: $inlineSources',
-    async ({ sourceMap, inlineSourceMap, inlineSources }: Record<string, boolean>) => {
+    "sourceMap: $sourceMap, inlineSourceMap: $inlineSourceMap, inlineSources: $inlineSources",
+    async ({
+      sourceMap,
+      inlineSourceMap,
+      inlineSources,
+    }: Record<string, boolean>) => {
       const { outputText, sourceMapText } = ts.transpileModule(inputText, {
         fileName: inputPath,
         compilerOptions: {
@@ -124,109 +130,119 @@ describe('detects files with source maps', () => {
           inlineSourceMap,
           inlineSources,
         },
-      });
+      })
 
       if (sourceMap) {
-        expect(sourceMapText).toBeDefined();
+        expect(sourceMapText).toBeDefined()
       } else {
-        expect(sourceMapText).toBeUndefined();
+        expect(sourceMapText).toBeUndefined()
       }
 
-      const { map } = await rollupBundle({ outputText, sourceMapText });
+      const { map } = await rollupBundle({ outputText, sourceMapText })
 
-      expect(map).toBeDefined();
-      expect(map?.sources.map(source => path.normalize(source))).toStrictEqual([inputPath]);
-      expect(map?.sourcesContent).toStrictEqual([inputText]);
-    },
-  );
-});
+      expect(map).toBeDefined()
+      expect(
+        map?.sources.map((source) => path.normalize(source))
+      ).toStrictEqual([inputPath])
+      expect(map?.sourcesContent).toStrictEqual([inputText])
+    }
+  )
+})
 
-describe('ignores filtered files', () => {
-  test('included', async () => {
+describe("ignores filtered files", () => {
+  test("included", async () => {
     const { outputText, sourceMapText } = ts.transpileModule(inputText, {
       fileName: inputPath,
       compilerOptions: {
         target: ts.ScriptTarget.ES2017,
         sourceMap: true,
       },
-    });
+    })
 
-    expect(sourceMapText).toBeDefined();
+    expect(sourceMapText).toBeDefined()
 
     const { map } = await rollupBundle({
       outputText,
       sourceMapText,
       pluginOptions: {
-        include: ['dummy-file'],
+        include: ["dummy-file"],
       },
-    });
+    })
 
-    expect(map).toBeDefined();
-    expect(map?.sources.map(source => path.normalize(source))).toStrictEqual([outputPath]);
-    expect(map?.sourcesContent).toStrictEqual([outputText]);
-  });
+    expect(map).toBeDefined()
+    expect(map?.sources.map((source) => path.normalize(source))).toStrictEqual([
+      outputPath,
+    ])
+    expect(map?.sourcesContent).toStrictEqual([outputText])
+  })
 
-  test('excluded', async () => {
+  test("excluded", async () => {
     const { outputText, sourceMapText } = ts.transpileModule(inputText, {
       fileName: inputPath,
       compilerOptions: {
         target: ts.ScriptTarget.ES2017,
         sourceMap: true,
       },
-    });
+    })
 
-    expect(sourceMapText).toBeDefined();
+    expect(sourceMapText).toBeDefined()
 
     const { map } = await rollupBundle({
       outputText,
       sourceMapText,
       pluginOptions: {
-        exclude: [path.relative(process.cwd(), outputPath).split('\\').join('/')],
+        exclude: [
+          path.relative(process.cwd(), outputPath).split("\\").join("/"),
+        ],
       },
-    });
+    })
 
-    expect(map).toBeDefined();
-    expect(map?.sources.map(source => path.normalize(source))).toStrictEqual([outputPath]);
-    expect(map?.sourcesContent).toStrictEqual([outputText]);
-  });
-});
+    expect(map).toBeDefined()
+    expect(map?.sources.map((source) => path.normalize(source))).toStrictEqual([
+      outputPath,
+    ])
+    expect(map?.sourcesContent).toStrictEqual([outputText])
+  })
+})
 
-it('delegates failing file reads to the next plugin', async () => {
+it("delegates failing file reads to the next plugin", async () => {
   const { outputText, sourceMapText } = ts.transpileModule(inputText, {
     fileName: inputPath,
     compilerOptions: {
       target: ts.ScriptTarget.ES2017,
       sourceMap: true,
     },
-  });
+  })
 
-  expect(sourceMapText).toBeDefined();
+  expect(sourceMapText).toBeDefined()
 
   const { map } = await rollupBundle({
     outputText,
     sourceMapText,
     pluginOptions: {
-      readFile(_path: string, cb: (error: Error | null, data: Buffer | string) => void) {
-        cb(new Error('Failed!'), '');
+      readFile(_path: string, cb: (error: Error | null, data: string) => void) {
+        cb(new Error("Failed!"), "")
       },
     },
-  });
+  })
 
-  expect(map).toBeDefined();
-  expect(map?.sources.map(source => path.normalize(source))).toStrictEqual([outputPath]);
-  expect(map?.sourcesContent).toStrictEqual([outputText]);
-});
+  expect(map).toBeDefined()
+  expect(map?.sources.map((source) => path.normalize(source))).toStrictEqual([
+    outputPath,
+  ])
+  expect(map?.sourcesContent).toStrictEqual([outputText])
+})
 
-it('handles failing source maps reads', async () => {
+it("handles failing source maps reads", async () => {
   const { outputText, sourceMapText } = ts.transpileModule(inputText, {
     fileName: inputPath,
     compilerOptions: {
       target: ts.ScriptTarget.ES2017,
       sourceMap: true,
     },
-  });
+  })
 
-  expect(sourceMapText).toBeDefined();
+  expect(sourceMapText).toBeDefined()
 
   const { map } = await rollupBundle({
     outputText,
@@ -235,45 +251,71 @@ it('handles failing source maps reads', async () => {
       readFile: util.callbackify(async (path: string) => {
         switch (path) {
           case inputPath:
-            return inputText;
+            return inputText
           case outputPath:
-            return outputText;
+            return outputText
           default:
-            throw new Error(`Unexpected path: ${path}`);
+            throw new Error(`Unexpected path: ${path}`)
         }
       }),
     },
-  });
+  })
 
-  expect(map).toBeDefined();
-  expect(map?.sources.map(source => path.normalize(source))).toStrictEqual([outputPath]);
-  expect(map?.sourcesContent).toStrictEqual([outputText]);
-});
+  expect(map).toBeDefined()
+  expect(map?.sources.map((source) => path.normalize(source))).toStrictEqual([
+    outputPath,
+  ])
+  expect(map?.sourcesContent).toStrictEqual([outputText])
+})
 
-it('finds last source map file definition', async () => {
+it("finds last source map file definition", async () => {
   const multipleSourceMappingFile = `
     function test(sourceMapUrl: string): string {
       return \`/*# sourceMappingURL=\${sourceMapUrl} */\`;
     }
     //# sourceMappingURL=index.js.map
-  `;
+  `
 
   const multipleSourceMappingMapFile =
-    '{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAAA,SAAS,IAAI,CAAC,YAAoB;IAChC,OAAO,+BAAwB,YAAY,QAAK,CAAC;AACnD,CAAC"}';
+    '{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAAA,SAAS,IAAI,CAAC,YAAoB;IAChC,OAAO,+BAAwB,YAAY,QAAK,CAAC;AACnD,CAAC"}'
 
-  let requestedSourceMap: string | null = null;
+  let requestedSourceMap: string | null = null
 
   const map = await resolveSourceMap(
     multipleSourceMappingFile,
-    '/dev/null/index.js',
-    async path => {
-      requestedSourceMap = path;
-      return multipleSourceMappingMapFile;
+    "/dev/null/index.js",
+    async (path) => {
+      requestedSourceMap = path
+      return multipleSourceMappingMapFile
+    }
+  )
+
+  expect(requestedSourceMap).toEqual("/dev/null/index.js.map")
+
+  expect(map).toBeDefined()
+  expect(map?.url).toEqual("/dev/null/index.js.map")
+})
+
+it("correctly handles Chinese and non-ASCII characters in source files", async () => {
+  // Chinese string
+  const chineseText = 'console.log("你好，世界！"); // 中文字符测试'
+  // Transpile with source map
+  const { outputText, sourceMapText } = ts.transpileModule(chineseText, {
+    fileName: inputPath,
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2017,
+      sourceMap: true,
+      inlineSourceMap: false,
+      inlineSources: true,
     },
-  );
+  })
 
-  expect(requestedSourceMap).toEqual('/dev/null/index.js.map');
+  expect(sourceMapText).toBeDefined()
 
-  expect(map).toBeDefined();
-  expect(map?.url).toEqual('/dev/null/index.js.map');
-});
+  const { map, code } = await rollupBundle({ outputText, sourceMapText })
+
+  // The code should contain the original Chinese characters
+  expect(code).toContain("你好，世界")
+  // The sourcesContent should also contain the original Chinese characters
+  expect(map?.sourcesContent?.[0]).toContain("你好，世界")
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,108 +1,101 @@
-import fs from "node:fs"
-import { promisify } from "node:util"
-import pluginUtils, { type CreateFilter } from "@rollup/pluginutils"
-import type { ExistingRawSourceMap, Plugin, PluginContext } from "rollup"
-import { resolveSourceMap, resolveSources } from "./source-map-resolve.js"
+import fs from 'node:fs';
+import { promisify } from 'node:util';
+import pluginUtils, { type CreateFilter } from '@rollup/pluginutils';
+import type { ExistingRawSourceMap, Plugin, PluginContext } from 'rollup';
+import { resolveSourceMap, resolveSources } from './source-map-resolve.js';
 
-const { createFilter } = pluginUtils
+const { createFilter } = pluginUtils;
 
 export interface SourcemapsPluginOptions {
-  include?: Parameters<CreateFilter>[0]
-  exclude?: Parameters<CreateFilter>[1]
-  readFile?(
-    path: string,
-    callback: (error: Error | null, data: string) => void
-  ): void
+  include?: Parameters<CreateFilter>[0];
+  exclude?: Parameters<CreateFilter>[1];
+  readFile?(path: string, callback: (error: Error | null, data: string) => void): void;
 }
 
 export default function sourcemaps(
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  { include, exclude, readFile }: SourcemapsPluginOptions = {}
+  { include, exclude, readFile }: SourcemapsPluginOptions = {},
 ): Plugin {
   // Create a filter function based on the include and exclude options
-  const filter = createFilter(include, exclude)
+  const filter = createFilter(include, exclude);
 
   // Default readFile that always reads as UTF-8 string
   const defaultReadFile = (
     path: string,
-    cb: (err: NodeJS.ErrnoException | null, data: string) => void
+    cb: (err: NodeJS.ErrnoException | null, data: string) => void,
   ) => {
-    fs.readFile(path, "utf8", cb)
-  }
+    fs.readFile(path, 'utf8', cb);
+  };
 
   // Use the provided readFile or the default one
-  const effectiveReadFile = readFile || defaultReadFile
+  const effectiveReadFile = readFile || defaultReadFile;
 
   // Promisify the readFile function
-  const promisifiedReadFile = promisify(effectiveReadFile)
+  const promisifiedReadFile = promisify(effectiveReadFile);
 
   return {
-    name: "sourcemaps",
+    name: 'sourcemaps',
 
     load: async function (this: PluginContext, id: string) {
-      let code: string
+      let code: string;
       // If the id does not pass the filter, return null
       if (!filter(id)) {
-        return null
+        return null;
       }
 
       try {
         // Try to read the file with the given id
-        code = await promisifiedReadFile(id)
+        code = await promisifiedReadFile(id);
         // Add the file to the watch list
-        this.addWatchFile(id)
+        this.addWatchFile(id);
       } catch {
         try {
           // If reading fails, try again without a query suffix that some plugins use
-          const cleanId = id.replace(/\?.*$/, "")
-          code = (await promisifiedReadFile(cleanId)).toString()
+          const cleanId = id.replace(/\?.*$/, '');
+          code = (await promisifiedReadFile(cleanId)).toString();
           // Add the file to the watch list
-          this.addWatchFile(cleanId)
+          this.addWatchFile(cleanId);
         } catch {
           // If reading still fails, warn and return null
-          this.warn("Failed reading file")
-          return null
+          this.warn('Failed reading file');
+          return null;
         }
       }
 
-      let map: ExistingRawSourceMap
+      let map: ExistingRawSourceMap;
       try {
         // Try to resolve the source map for the code
-        const result = await resolveSourceMap(code, id, promisifiedReadFile)
+        const result = await resolveSourceMap(code, id, promisifiedReadFile);
 
         // If the code contained no sourceMappingURL, return the code
         if (result === null) {
-          return code
+          return code;
         }
 
         // If the source map was resolved, assign it to map
-        map = result.map
+        map = result.map;
       } catch {
         // If resolving the source map fails, warn and return the code
-        this.warn("Failed resolving source map")
-        return code
+        this.warn('Failed resolving source map');
+        return code;
       }
 
       // If the sources are not included in the map, try to resolve them
       if (map.sourcesContent === undefined) {
         try {
-          const { sourcesContent } = await resolveSources(
-            map,
-            id,
-            promisifiedReadFile
-          )
+          const { sourcesContent } = await resolveSources(map, id, promisifiedReadFile);
           // If all sources are strings, assign them to map.sourcesContent
-          if (sourcesContent.every((item) => typeof item === "string")) {
-            map.sourcesContent = sourcesContent
+          if (sourcesContent.every(item => typeof item === 'string')) {
+            map.sourcesContent = sourcesContent;
           }
         } catch {
           // If resolving the sources fails, warn
-          this.warn("Failed resolving sources for source map")
+          this.warn('Failed resolving sources for source map');
         }
       }
 
       // Return the code and the map
-      return { code, map }
+      return { code, map };
     },
-  }
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,90 +1,108 @@
-import fs from 'node:fs';
-import { promisify } from 'node:util';
-import pluginUtils, { type CreateFilter } from '@rollup/pluginutils';
-import type { ExistingRawSourceMap, Plugin, PluginContext } from 'rollup';
-import { resolveSourceMap, resolveSources } from './source-map-resolve.js';
+import fs from "node:fs"
+import { promisify } from "node:util"
+import pluginUtils, { type CreateFilter } from "@rollup/pluginutils"
+import type { ExistingRawSourceMap, Plugin, PluginContext } from "rollup"
+import { resolveSourceMap, resolveSources } from "./source-map-resolve.js"
 
-const { createFilter } = pluginUtils;
+const { createFilter } = pluginUtils
 
 export interface SourcemapsPluginOptions {
-  include?: Parameters<CreateFilter>[0];
-  exclude?: Parameters<CreateFilter>[1];
-  readFile?(path: string, callback: (error: Error | null, data: Buffer | string) => void): void;
+  include?: Parameters<CreateFilter>[0]
+  exclude?: Parameters<CreateFilter>[1]
+  readFile?(
+    path: string,
+    callback: (error: Error | null, data: string) => void
+  ): void
 }
 
 export default function sourcemaps(
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  { include, exclude, readFile = fs.readFile }: SourcemapsPluginOptions = {},
+  { include, exclude, readFile }: SourcemapsPluginOptions = {}
 ): Plugin {
   // Create a filter function based on the include and exclude options
-  const filter = createFilter(include, exclude);
+  const filter = createFilter(include, exclude)
+
+  // Default readFile that always reads as UTF-8 string
+  const defaultReadFile = (
+    path: string,
+    cb: (err: NodeJS.ErrnoException | null, data: string) => void
+  ) => {
+    fs.readFile(path, "utf8", cb)
+  }
+
+  // Use the provided readFile or the default one
+  const effectiveReadFile = readFile || defaultReadFile
 
   // Promisify the readFile function
-  const promisifiedReadFile = promisify(readFile);
+  const promisifiedReadFile = promisify(effectiveReadFile)
 
   return {
-    name: 'sourcemaps',
+    name: "sourcemaps",
 
     load: async function (this: PluginContext, id: string) {
-      let code: string;
+      let code: string
       // If the id does not pass the filter, return null
       if (!filter(id)) {
-        return null;
+        return null
       }
 
       try {
         // Try to read the file with the given id
-        code = (await promisifiedReadFile(id)).toString();
+        code = await promisifiedReadFile(id)
         // Add the file to the watch list
-        this.addWatchFile(id);
+        this.addWatchFile(id)
       } catch {
         try {
           // If reading fails, try again without a query suffix that some plugins use
-          const cleanId = id.replace(/\?.*$/, '');
-          code = (await promisifiedReadFile(cleanId)).toString();
+          const cleanId = id.replace(/\?.*$/, "")
+          code = (await promisifiedReadFile(cleanId)).toString()
           // Add the file to the watch list
-          this.addWatchFile(cleanId);
+          this.addWatchFile(cleanId)
         } catch {
           // If reading still fails, warn and return null
-          this.warn('Failed reading file');
-          return null;
+          this.warn("Failed reading file")
+          return null
         }
       }
 
-      let map: ExistingRawSourceMap;
+      let map: ExistingRawSourceMap
       try {
         // Try to resolve the source map for the code
-        const result = await resolveSourceMap(code, id, promisifiedReadFile);
+        const result = await resolveSourceMap(code, id, promisifiedReadFile)
 
         // If the code contained no sourceMappingURL, return the code
         if (result === null) {
-          return code;
+          return code
         }
 
         // If the source map was resolved, assign it to map
-        map = result.map;
+        map = result.map
       } catch {
         // If resolving the source map fails, warn and return the code
-        this.warn('Failed resolving source map');
-        return code;
+        this.warn("Failed resolving source map")
+        return code
       }
 
       // If the sources are not included in the map, try to resolve them
       if (map.sourcesContent === undefined) {
         try {
-          const { sourcesContent } = await resolveSources(map, id, promisifiedReadFile);
+          const { sourcesContent } = await resolveSources(
+            map,
+            id,
+            promisifiedReadFile
+          )
           // If all sources are strings, assign them to map.sourcesContent
-          if (sourcesContent.every(item => typeof item === 'string')) {
-            map.sourcesContent = sourcesContent;
+          if (sourcesContent.every((item) => typeof item === "string")) {
+            map.sourcesContent = sourcesContent
           }
         } catch {
           // If resolving the sources fails, warn
-          this.warn('Failed resolving sources for source map');
+          this.warn("Failed resolving sources for source map")
         }
       }
 
       // Return the code and the map
-      return { code, map };
+      return { code, map }
     },
-  };
+  }
 }


### PR DESCRIPTION
## 🚀 Pull Request

### Description

This fixes the issue we had where non ascii characters were not being encoded properly when reading the file.

### Changes Made

- The callback for readFile now accepts a string not a buffer & we encode files by default

### Related Issues

#250 

### Checklist

- [x] I have tested the changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added appropriate comments where necessary.
- [x] All tests pass successfully.
- [ ] I have squashed and rebased my commits.

