### PR TITLE
chore: add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "type": "git",
     "url": "git+https://github.com/2wce/rollup-plugin-sourcemaps2.git"
   },
+  "homepage": "https://github.com/2wce/rollup-plugin-sourcemaps2#readme",
+  "bugs": {
+    "url": "https://github.com/2wce/rollup-plugin-sourcemaps2/issues"
+  },
   "engines": {
     "node": ">=22.13.0"
   },


### PR DESCRIPTION
## Summary

- add standard npm `homepage` metadata pointing at the existing README
- add standard npm `bugs.url` metadata pointing at the existing issue tracker
- leave runtime code, dependencies, version, repository metadata, and package exports unchanged

## Verification

```sh
npm view rollup-plugin-sourcemaps2@0.5.7 name version homepage repository bugs --json
node metadata smoke check for repository/homepage/bugs
npm pack --dry-run --ignore-scripts
npx --yes pnpm@11.1.0 install --frozen-lockfile --ignore-scripts
npx --yes pnpm@11.1.0 run lint:ci
npx --yes pnpm@11.1.0 run typecheck
npx --yes pnpm@11.1.0 run test
npx --yes pnpm@11.1.0 run build
npm pack --dry-run --ignore-scripts
git diff --check
```

Notes:

- `lint:ci` exits 0 and reports an existing Biome schema version info message.
- `test` exits 0 with 1 test file / 11 tests passed and reports an existing Vite missing source map warning for `index.js.map`.
- Post-build `npm pack --dry-run --ignore-scripts` includes the generated `dist` files.