### PR TITLE
chore: add npm homepage and bugs metadata

### DIFF
--- a/.changeset/add-npm-homepage-bugs-metadata.md
+++ b/.changeset/add-npm-homepage-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+"rollup-plugin-sourcemaps2": patch
+---
+
+Add npm `homepage` and `bugs.url` metadata fields to package.json

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Rollup plugin for grabbing source maps from sourceMappingURLs",
   "author": "Kudakwashe Mupeni <said.coyness-0m@icloud.com>",
   "license": "MIT",
+  "homepage": "https://github.com/2wce/rollup-plugin-sourcemaps2#readme",
+  "bugs": {
+    "url": "https://github.com/2wce/rollup-plugin-sourcemaps2/issues"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Add standard npm `homepage` field pointing at the README anchor
- Add standard npm `bugs.url` field pointing at the issue tracker
- Fields placed adjacent to `description`/`author`/`license` for consistent identity-field grouping

No runtime code, dependencies, version, or exports changed.

## Motivation

These are standard npm registry metadata fields that improve discoverability and usability on npmjs.com — the package page will surface a homepage link and a direct "report a bug" URL.

## Verification

```sh
npm pack --dry-run --ignore-scripts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)