### PR TITLE
chore: fix publish job to use pnpm consistently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,11 +127,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Use Node.js 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.x
+          cache: 'pnpm'
           registry-url: https://registry.npmjs.org
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
 
       - name: Download build artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -140,4 +147,4 @@ jobs:
           path: dist/
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: pnpm publish --provenance --access public --no-git-checks


### PR DESCRIPTION
## Summary

- Add `corepack enable` + `pnpm install` to the `publish` job
- Switch `npm publish` → `pnpm publish --no-git-checks`
- Add `cache: 'pnpm'` to the Node setup step for consistency with other jobs

## Problem

The `publish` job was the only job in the workflow that skipped corepack/pnpm setup. When `npm publish` triggered `prepublishOnly` → `prebuild`, `rimraf` wasn't on the PATH (it's a dev dependency managed by pnpm), causing:

```
sh: rimraf: command not found
npm error code 127
```

## Why `--no-git-checks`

`pnpm publish` by default verifies the working tree is clean, but in CI the `dist/` artifact is downloaded separately after the build job, leaving the tree dirty. The flag skips that check safely since provenance still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)