### PR TITLE
chore: migrate biome config to 2.5.0

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "formatter": {
     "enabled": true,
@@ -14,7 +14,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "style": {
         "noParameterAssign": "error",
         "useAsConstAssertion": "error",


### PR DESCRIPTION
## Summary

- Update `$schema` from `2.4.15` to `2.5.0`
- Replace deprecated `recommended: true` with `preset: "recommended"` in linter rules

## Problem

`biome ci` was emitting two notices on every run:
1. Schema version mismatch (config declared 2.4.15, CLI is 2.5.0)
2. `recommended` field is deprecated in favour of `preset`

These are logged as infos but clutter CI output and will become errors in the next major Biome version.

## Verification

```sh
pnpm lint:ci  # exits 0, no notices
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)