### PR TITLE
fix: skip publish when version is already on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,5 +146,18 @@ jobs:
           name: dist
           path: dist/
 
+      - name: Check if version is already published
+        id: version-check
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PUBLISHED=$(npm view rollup-plugin-sourcemaps2@"$PACKAGE_VERSION" version 2>/dev/null || true)
+          if [ -n "$PUBLISHED" ]; then
+            echo "Version $PACKAGE_VERSION is already published, skipping."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
+        if: steps.version-check.outputs.should_publish == 'true'
         run: pnpm publish --provenance --access public --no-git-checks


### PR DESCRIPTION
## Summary

- The `publish` job was firing on every push to `main` where no changeset existed — including regular chore/fix commits — causing a 403 when the current version was already published on npm.
- Added a `version-check` step that queries npm for the current `package.json` version before publishing; skips the publish step if already released.

## Root cause

The job condition `has_changesets == 'false'` is true for *two* cases:
1. ✅ A "Version packages" PR just merged (new version, ready to publish)
2. ❌ Any regular commit on main with no changeset (same version, already published)

## Test plan

- [ ] Merge a regular chore commit to main — `publish` job should run but skip the publish step with "Version X.X.X is already published"
- [ ] Merge a "Version packages" PR — publish step should proceed normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)